### PR TITLE
Fix Gsettings schema path

### DIFF
--- a/org.mate.system-tools.gschema.xml.in
+++ b/org.mate.system-tools.gschema.xml.in
@@ -1,5 +1,5 @@
 <schemalist>
-  <schema id="org.mate.system-tools.users" path="/apps/mate-system-tools/users/">
+  <schema id="org.mate.system-tools.users" path="/org/mate/system-tools/users/">
     <key name="showall" type="b">
       <default>false</default>
       <_summary>Show system users</_summary>


### PR DESCRIPTION
The gschema path was using /apps/, which is deprecated. This patch changes the path to /org/mate/system-tools/users/. Also, there's no mateconf usage since this package uses Gsettings already.
