### PR TITLE
Also show MATE system tools in XFCE

### DIFF
--- a/src/network/mate-network.desktop.in.in
+++ b/src/network/mate-network.desktop.in.in
@@ -11,5 +11,5 @@ X-MATE-Bugzilla-Bugzilla=MATE
 X-MATE-Bugzilla-Product=mate-system-tools
 X-MATE-Bugzilla-Component=network-admin
 X-MATE-Bugzilla-Version=@VERSION@
-OnlyShowIn=MATE;
+OnlyShowIn=MATE;XFCE;
 StartupNotify=true

--- a/src/services/mate-services.desktop.in.in
+++ b/src/services/mate-services.desktop.in.in
@@ -11,5 +11,5 @@ X-MATE-Bugzilla-Bugzilla=MATE
 X-MATE-Bugzilla-Product=mate-system-tools
 X-MATE-Bugzilla-Component=runlevel-admin
 X-MATE-Bugzilla-Version=@VERSION@
-OnlyShowIn=MATE;
+OnlyShowIn=MATE;XFCE;
 StartupNotify=true

--- a/src/shares/mate-shares.desktop.in.in
+++ b/src/shares/mate-shares.desktop.in.in
@@ -11,6 +11,6 @@ X-MATE-Bugzilla-Bugzilla=MATE
 X-MATE-Bugzilla-Product=mate-system-tools
 X-MATE-Bugzilla-Component=shares-admin
 X-MATE-Bugzilla-Version=@VERSION@
-OnlyShowIn=MATE;
+OnlyShowIn=MATE;XFCE;
 StartupNotify=true
 

--- a/src/time/mate-time.desktop.in.in
+++ b/src/time/mate-time.desktop.in.in
@@ -11,5 +11,5 @@ X-MATE-Bugzilla-Bugzilla=MATE
 X-MATE-Bugzilla-Product=mate-system-tools
 X-MATE-Bugzilla-Component=mate-time-admin
 X-MATE-Bugzilla-Version=@VERSION@
-OnlyShowIn=MATE;
+OnlyShowIn=MATE;XFCE;
 StartupNotify=true

--- a/src/users/mate-users.desktop.in.in
+++ b/src/users/mate-users.desktop.in.in
@@ -11,5 +11,5 @@ X-MATE-Bugzilla-Bugzilla=MATE
 X-MATE-Bugzilla-Product=mate-system-tools
 X-MATE-Bugzilla-Component=users-admin
 X-MATE-Bugzilla-Version=@VERSION@
-OnlyShowIn=MATE;
+OnlyShowIn=MATE;XFCE;
 StartupNotify=true


### PR DESCRIPTION
The MATE system tools are really handy in XFCE (which doesn't have its own). 

Until now Xfce relied on gnome-system-tools which no longer contains date-time settings (moved to gnome-control-center).
